### PR TITLE
hotfix for issue 56

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/raml-org/ramldt2jsonschema",
   "files": [
-    "src/**"
+    "src/**",
+    "bin/**"
   ],
   "keywords": [
     "raml",


### PR DESCRIPTION
Here's a hotfix proposal for [the issue I just created](https://github.com/raml-org/ramldt2jsonschema/issues/56).

 Given the nature of the problem (that it's related to npm downloads) I can't test it on my end, but it should do the job just fine.