### PR TITLE
Fix for wrong required in nontype properties (issue #65)

### DIFF
--- a/src/dt2js.js
+++ b/src/dt2js.js
@@ -393,7 +393,7 @@ function schemaForm (data, reqStack = [], prop) {
     return data
   }
   const lastEl = reqStack[reqStack.length - 1]
-  if (data.required !== false && lastEl && prop) {
+  if (data.type && data.required !== false && lastEl && prop) {
     if (lastEl.props.indexOf(prop) > -1 && (prop[0] + prop[prop.length - 1]) !== '//') {
       lastEl.reqs.push(prop)
     }

--- a/test/dt2js.test.js
+++ b/test/dt2js.test.js
@@ -13,6 +13,7 @@ const ARRAY_OF_UNION_TEST = join(__dirname, 'examples/union_test.raml')
 const UNION_TEST = join(__dirname, 'examples/union_test2.raml')
 const DUPLICATE_REQUIRED_ENTRY = join(__dirname, 'examples/duplicate_required_entry_test.raml')
 const TYPE_CONVERSION_TEST = join(__dirname, 'examples/type_conversion_test.raml')
+const REQUIRED_TEST = join(__dirname, 'examples/required_test.raml')
 
 describe('dt2js.getRAMLContext()', function () {
   const ramlData = fs.readFileSync(RAML_FILE).toString()
@@ -476,5 +477,13 @@ describe('When property with name "items".', function () {
     const schema = dt2js.dt2js(ramlData, 'Foo')
     expect(schema.required).to.deep.equal(['items', 'total_count'])
     return cb()
+  })
+})
+describe('File with diferent kind of required types', function () {
+  it('should set required for `require: true` or without `required` types', function () {
+    const ramlData = fs.readFileSync(REQUIRED_TEST).toString()
+    const schema = dt2js.dt2js(ramlData, 'randomObject')
+    const expected = require(join(__dirname, 'examples/required_test_result.json'))
+    expect(schema).to.deep.equal(expected)
   })
 })

--- a/test/dt2js.test.js
+++ b/test/dt2js.test.js
@@ -383,10 +383,6 @@ describe('dt2js.schemaForm()', function () {
     expect(schema).to.have.nested.property('properties.photo.media')
     expect(schema).to.have.nested.property('properties.dob.type', 'string')
   })
-})
-
-describe('dt2js.schemaForm()', function () {
-  const schemaForm = dt2js.__get__('schemaForm')
   it('should interpret absence of `required` as required: true', function () {
     const data = {
       'type': 'object',
@@ -414,6 +410,40 @@ describe('dt2js.schemaForm()', function () {
       .to.have.nested.property('properties.key1.default', 1)
     expect(schema)
       .to.have.nested.property('properties.key3.default', true)
+  })
+  it('should not add non-types properties without `required` to required list', function () {
+    const data = {
+      'type': 'object',
+      'example': {
+        'key1': {
+          'key11': 'lorem ipsum'
+        },
+        'key2': 'lorem ipsum'
+      },
+      'properties': {
+        'key1': {
+          'type': 'object',
+          'required': false,
+          'properties': {
+            'key11': {
+              'type': 'string',
+              'required': true
+            }
+          }
+        },
+        'key2': {
+          'type': 'string',
+          'required': true
+        }
+      }
+    }
+    const schema = schemaForm(data, [])
+    expect(schema)
+      .to.have.property('required').and
+      .to.be.deep.equal(['key2'])
+    expect(schema)
+      .to.have.nested.property('properties.key1.required').and
+      .to.be.deep.equal(['key11'])
   })
 })
 describe('Converting an array of union type', function () {

--- a/test/examples/required_test.raml
+++ b/test/examples/required_test.raml
@@ -1,0 +1,22 @@
+#%RAML 1.0 Library
+
+types:
+  randomObject:
+    type: object
+    example: !include someExample.json
+    properties:
+      key1:
+        type: object
+        required: false
+        properties:
+          key11: string
+      key2:
+        type: object
+        properties:
+          key21?: string
+      key3:
+        type: object
+        required: true
+      properties:
+        type: object
+        required: false

--- a/test/examples/required_test_result.json
+++ b/test/examples/required_test_result.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "example": {
+    "key1": {
+      "key11": "lorem ipsum"
+    },
+    "key2": {},
+    "key3": {
+      "key32": "lorem ipsum"
+    }
+  },
+  "properties": {
+    "key1": {
+      "type": "object",
+      "properties": {
+        "key11": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "key11"
+      ]
+    },
+    "key2": {
+      "type": "object",
+      "properties": {
+        "key21": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "key3": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {}
+    },
+    "properties": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {}
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "key2",
+    "key3"
+  ],
+  "$schema": "http://json-schema.org/draft-06/schema#"
+}

--- a/test/examples/someExample.json
+++ b/test/examples/someExample.json
@@ -1,0 +1,10 @@
+{
+  "key1": {
+    "key11": "lorem ipsum"
+  },
+  "key2": {
+  },
+  "key3": {
+    "key32": "lorem ipsum"
+  }
+}


### PR DESCRIPTION
Hi there!

This PR fix the problem described in issue #65. I think the problem is that schemaForm function try to add every kind of props to required list, but the function could also receive things like "examples", "properties" and other kind of json objects that not represent a type (string, object, integer, arrays...).

I add a test and an example file with multiple kind of required examples to avoid this problem in the future.

Regards!