### PR TITLE
fixed error in integration tests

### DIFF
--- a/test/integration/json/complex_product.json
+++ b/test/integration/json/complex_product.json
@@ -21,7 +21,7 @@
         },
         "importedAt": {
           "allOf": [
-            {"type": "string", "pattern": "^(\\d{2})(:)(\\d{2})(:)(\\d{2})(\\.\\d+)?$"},
+            {"type": "string", "pattern": "^(\\d{2})(:)(\\d{2})(:)(\\d{2})(\\.\\d+)?"},
             {"type": "string", "minLength": 3}
           ]
         },


### PR DESCRIPTION
Changed pattern, now it is not time-only type. 
Fixed error in tests when [build](https://travis-ci.org/raml-org/ramldt2jsonschema/jobs/479093472#L810):  "Restrictions conflict in type 'TestTypeParentType0,importedAt': should be of type string and should be of type time-only".