### PR TITLE
Fix/dt2js reduce size output file

### DIFF
--- a/src/dt2js.js
+++ b/src/dt2js.js
@@ -216,7 +216,7 @@ function dt2js (ramlData, typeName) {
   if (ctx[typeName] === undefined) throw new Error('type ' + typeName + ' does not exist')
 
   const expanded = expandedForm(ctx[typeName], ctx)
-  const canonical = canonicalForm(expanded)
+  const canonical = canonicalForm(expanded, { hoistUnions: false })
 
   let schema = schemaForm(canonical)
   schema = addRootKeywords(schema)


### PR DESCRIPTION
For details see issues [#75](https://github.com/raml-org/datatype-expansion/issues/75) and [#49](https://github.com/raml-org/datatype-expansion/issues/49) in `datatype-expansion`.
Without `{ hoistUnions: false }` result JSON file may be very big if use union like `string | nil`.