### PR TITLE
Fixes #55: Validate JSON Schema output of dt2js

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This will install two command-line tools:
 #### dt2js
 
 ```
-dt2js <ramlFile> <ramlTypeName> --draft=[version]
+dt2js <ramlFile> <ramlTypeName> --draft=[version] [--validate]
 ```
 
 **Options**
@@ -31,6 +31,7 @@ dt2js <ramlFile> <ramlTypeName> --draft=[version]
 * `<ramlFile>` Path to a file containing at least one RAML data type (e.g. `path/to/api.raml`)
 * `<ramlTypeName>` RAML type name to convert to JSON schema
 * `--draft` Optional JSON Shema draft version to convert to. Supported values are: `04`, `06` and `07` (default)
+* `--validate` Validate output JSON Schema with Ajv. Throws an error if schema is invalid. Requires "ajv" to be installed. (default: false)
 
 #### js2dt
 

--- a/bin/dt2js.js
+++ b/bin/dt2js.js
@@ -9,6 +9,11 @@ program
   .option(
     '--draft <num>',
     'JSON Shema draft version to convert to. Supported values are: "04", "06" and "07" (default)')
+  .option(
+    '--validate',
+    'Validate output JSON Schema with Ajv. Throws an error if schema is invalid. ' +
+    'Requires "ajv" to be installed.',
+    false)
   .description('Convert a RAML data type into JSON schema. ' +
                'Writes to standard output.')
   .action(async (f, t, opts) => {


### PR DESCRIPTION
Fixes #55: Validate JSON Schema output of dt2js

I didn't add `ajv` as an optional dependency to `package.json` because currently supported properties of it serve different purposes.
`optionalDependencies` - installs deps any way;
`peerDependencies` - is used to specify with which "parent"-package the lib works.